### PR TITLE
GitHub Actions badge

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,23 @@
+name: build_master
+on:
+  push:
+    branches: [feature/github-actions-badge] #TODO change to master
+
+jobs:
+  build:
+    name: Build master branch
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Run unit tests
+        shell: bash
+        run: ./gradlew --continue testRelease
+      - name: Build
+        run: ./gradlew build

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,7 @@
 name: master
 on:
   push:
-    branches: [master]
+    branches: [feature/github-actions-badge]
 
 jobs:
   build:
@@ -9,9 +9,6 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.6'
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,4 +1,4 @@
-name: build_master
+name: master
 on:
   push:
     branches: [feature/github-actions-badge] #TODO change to master

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,7 @@
 name: master
 on:
   push:
-    branches: [feature/github-actions-badge] #TODO change to master
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,7 @@
 name: master
 on:
   push:
-    branches: [feature/github-actions-badge]
+    branches: [master]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Download](https://api.bintray.com/packages/thefuntastyops/donut/donut/images/download.svg) ](https://bintray.com/thefuntastyops/donut/donut/_latestVersion)
-[![Build Status](https://app.bitrise.io/app/e9f4fbbcc143c212/status.svg?token=LK6EaX0H10eB3wjz5k-HlQ&branch=master)](https://app.bitrise.io/app/e9f4fbbcc143c212)
+[![Build Status](https://github.com/futuredapp/donut/workflows/master/badge.svg)](https://github.com/futuredapp/donut/actions)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Donut-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/8015)
 
 # Donut 🍩

--- a/sample/lint.xml
+++ b/sample/lint.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lint></lint>
+<lint>
+    <issue id="StringFormatMatches" severity="ignore" />
+</lint>


### PR DESCRIPTION
Created basic build workflow that triggers on each push to master branch. It's used to generate build status badge, since we migrated to GH Actions recently.
Replaced Bitrise badge with GitHub Actions badge.

Resolves #34 