### PR TITLE
Support SDK Version 19

### DIFF
--- a/library/src/main/kotlin/app/futured/donut/DonutProgressView.kt
+++ b/library/src/main/kotlin/app/futured/donut/DonutProgressView.kt
@@ -24,7 +24,7 @@ class DonutProgressView @JvmOverloads constructor(
     private val attrs: AttributeSet? = null,
     private val defStyleAttr: Int = 0,
     private val defStyleRes: Int = 0
-) : View(context, attrs, defStyleAttr, defStyleRes) {
+) : View(context, attrs, defStyleAttr) {
 
     companion object {
         private const val TAG = "DonutProgressView"


### PR DESCRIPTION
In order to support SDK Version 19 (forcing it to use SDK 19 in manifest and successfully compiled), use another constructor that still support SDK version 19. But I don't know if this change will break other feature like Jetpack Compose or not.