### PR TITLE
Give addAmount functionality to section with 0f amount

### DIFF
--- a/library/src/main/kotlin/app/futured/donut/DonutProgressView.kt
+++ b/library/src/main/kotlin/app/futured/donut/DonutProgressView.kt
@@ -228,7 +228,7 @@ class DonutProgressView @JvmOverloads constructor(
         assertDataConsistency(sections)
 
         sections
-            .filter { it.amount > 0f }
+            .filter { it.amount >= 0f }
             .forEach { section ->
                 val newLineColor = section.color
                 if (hasEntriesForSection(section.name).not()) {


### PR DESCRIPTION
Before, we can't addAmount to the section that has 0f amount because basically, the section doesn't exist.