### PR TITLE
Lower :library module minSdk to 19

### DIFF
--- a/buildSrc/src/main/kotlin/ProjectSettings.kt
+++ b/buildSrc/src/main/kotlin/ProjectSettings.kt
@@ -1,6 +1,7 @@
 object ProjectSettings {
     const val applicationId = "app.futured.donut"
     const val targetSdk = 29
+    const val minSdkLibrary = 19
     const val minSdk = 21
     const val group = "app.futured.donut"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     // gradle
-    const val gradle = "4.1.0-alpha09"
+    const val gradle = "4.1.0-rc01"
 
     // kotlin
     const val kotlin = "1.3.72"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/library-compose/build.gradle.kts
+++ b/library-compose/build.gradle.kts
@@ -42,9 +42,7 @@ android {
     }
 
     packagingOptions {
-        val newExcludes = getExcludes()
-        newExcludes.remove("/META-INF/*.kotlin_module")
-        excludes = newExcludes
+        excludes -= "/META-INF/*.kotlin_module"
     }
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     compileSdkVersion(ProjectSettings.targetSdk)
 
     defaultConfig {
-        minSdkVersion(ProjectSettings.minSdk)
+        minSdkVersion(ProjectSettings.minSdkLibrary)
         targetSdkVersion(ProjectSettings.targetSdk)
     }
 

--- a/library/src/main/kotlin/app/futured/donut/DonutProgressView.kt
+++ b/library/src/main/kotlin/app/futured/donut/DonutProgressView.kt
@@ -22,9 +22,8 @@ import app.futured.donut.extensions.sumByFloat
 class DonutProgressView @JvmOverloads constructor(
     context: Context,
     private val attrs: AttributeSet? = null,
-    private val defStyleAttr: Int = 0,
-    private val defStyleRes: Int = 0
-) : View(context, attrs, defStyleAttr, defStyleRes) {
+    private val defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
 
     companion object {
         private const val TAG = "DonutProgressView"
@@ -168,7 +167,7 @@ class DonutProgressView @JvmOverloads constructor(
             attrs,
             R.styleable.DonutProgressView,
             defStyleAttr,
-            defStyleRes
+            0
         ).use {
             strokeWidth = it.getDimensionPixelSize(
                 R.styleable.DonutProgressView_donut_strokeWidth,


### PR DESCRIPTION
There is no need to limit :library to minSdk 21 since library can be fully functional without any problems on lower API devices.
Solves #53.