### PR TITLE
fix: Remove reversing of the sections in compose version

### DIFF
--- a/library-compose/src/main/java/app/futured/donut/compose/Donut.kt
+++ b/library-compose/src/main/java/app/futured/donut/compose/Donut.kt
@@ -186,7 +186,7 @@ private fun createPathDataForSections(data: SectionsPathData): List<DonutPathDat
         angleAccumulator += entryAngle
     }
 
-    return entriesPathData.reversed()
+    return entriesPathData
 }
 
 private fun DrawScope.drawDonutSegment(

--- a/sample/src/main/kotlin/app/futured/donutsample/ui/playground/compose/PlaygroundComposeActivity.kt
+++ b/sample/src/main/kotlin/app/futured/donutsample/ui/playground/compose/PlaygroundComposeActivity.kt
@@ -90,10 +90,10 @@ class PlaygroundComposeActivity : AppCompatActivity() {
             data.value = data.value.copy(
                 masterProgress = 1f,
                 sections = listOf(
-                    DonutSection(amount = 1f, color = Color(0xFF222222)),
+                    DonutSection(amount = 0.5f, color = Color(0xFF222222)),
                     DonutSection(amount = 1f, color = Color(0xFF19D3C5)),
-                    DonutSection(amount = 1f, color = Color(0xFFFF5F00)),
-                    DonutSection(amount = 1f, color = Color(0xFF005FCC))
+                    DonutSection(amount = 1.5f, color = Color(0xFFFF5F00)),
+                    DonutSection(amount = 2f, color = Color(0xFF005FCC))
                 )
             )
         }, DATA_DELAY)


### PR DESCRIPTION
@matejsemancik this is fix for the following issue https://github.com/futuredapp/donut/issues/83 since colors are separated from the data and data are reversed, there is a bug that was causing the colors were not assigned to the correct values. It is clearly a bug, but it is going to reverse colors for everybody who is going to update the library. Do you think that we should proceed with this change and add a comment to the changelog or fix the issue somehow differently?