### PR TITLE
hotfix: don't override version in maven publishing configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
+VERSION_NAME=2.X.X-SNAPSHOT
 mavenCentralPublishing=true
 signAllPublications=true

--- a/library-compose/build.gradle.kts
+++ b/library-compose/build.gradle.kts
@@ -62,8 +62,7 @@ android {
 mavenPublishing {
     coordinates(
         groupId = "app.futured.donut",
-        artifactId = "donut-compose",
-        version = project.findProperty("VERSION_NAME") as String? ?: "2.X.X-SNAPSHOT"
+        artifactId = "donut-compose"
     )
 
     pom {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -37,8 +37,7 @@ dependencies {
 mavenPublishing {
     coordinates(
         groupId = "app.futured.donut",
-        artifactId = "donut",
-        version = project.findProperty("VERSION_NAME") as String? ?: "2.X.X-SNAPSHOT"
+        artifactId = "donut"
     )
 
     pom {


### PR DESCRIPTION
## Problem
  Release publish was failing on CI with:
    "The value for extension 'mavenPublishing' property 'version$plugin' is
  final and cannot be changed any further."

  vanniktech/gradle-maven-publish-plugin 0.34.0 automatically reads
  `VERSION_NAME`
  from Gradle project properties and finalizes the version field during plugin
  configuration. The explicit `coordinates(version = ...)` call then tried to
  overwrite an already-finalized value.

  Snapshot publish worked because it doesn't pass `-PVERSION_NAME`, so the
  plugin
  never finalized the property.

  ## Fix
  - Remove `version` from `coordinates()` in both library build files — the
  plugin
    reads `VERSION_NAME` natively.
  - Add `VERSION_NAME=2.X.X-SNAPSHOT` to `gradle.properties` as the default for
    snapshot builds. Release CI overrides it with `-PVERSION_NAME=x.y.z`.
